### PR TITLE
update typing extensions package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -315,11 +315,11 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "zipp"
@@ -336,7 +336,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "d3866e2a097e4d225d22b414fe1ae991fb10fe4d957b38bb43d606870af47971"
+content-hash = "6fa57ce550768bd20bd9e9c8d487298427be50afccfc21cae32739244c8f4b7f"
 
 [metadata.files]
 atomicwrites = [
@@ -585,9 +585,8 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 zipp = [
     {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ packages = [
 python = "^3.7"
 click = "^7.1.2"
 click-help-colors = "^0.8"
-typing_extensions = { version =  "^3.7.4" }
 click-completion = "^0.5.2"
+typing-extensions = "^4.1.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "==6.0.1"


### PR DESCRIPTION
This package is updated to v4 in many python packages, which makes `poetry` projects using those libraries and `glacier` incompatible.

@relastle, would you consider adding Dependabot to this project?

Thanks for this great library!